### PR TITLE
Fix Sort 4 test

### DIFF
--- a/source/tests/main.cpp
+++ b/source/tests/main.cpp
@@ -1075,6 +1075,8 @@ past_last = list.erase( std::next(list.begin(),2) );
             { return value < a.value; }
             inline bool operator==( const Card &a ) const
             { return value == a.value; }
+            inline bool operator!=( const Card &a ) const
+            { return value != a.value; }
         };
         which_lib::list<Card> list_a{
             { 10, "clubs"},
@@ -1103,13 +1105,13 @@ past_last = list.erase( std::next(list.begin(),2) );
         *add_first = {100, "CLUBS"}; // Iterators must remain valid.
         *add_last = {80, "CLUBS"};
         which_lib::list<Card> list_r2{
-            { 4, "hearts" },
+            { 100, "CLUBS" },
             { 4, "clubs" },
             { 7, "spades" },
             { 8, "diamond" },
+            { 8, "CLUBS" },
+            { 10, "CLUBS"},
             { 80, "CLUBS" },
-            { 100, "CLUBS"},
-            { 10, "spades" },
         };
         EXPECT_EQ( list_r2, list_a ); // List A must be equal to list Result.
     }


### PR DESCRIPTION
- Add `operator!=` in `Card`
*Reason*: Some implementations of list's  operators `==` and/or `!=` could use it instead of just `operator==`

- Change values of `list_r2` accordingly to be equals to `list_a`
*Reason*:
  - `{100, "CLUBS"}` is set to the first element of `list_a` not the "penult", like was supposed in `list_r2`
  - `{80, "CLUBS"}` is set to the last element of de `list_a` not the "penult penult", like was supposed in `list_r2`
  - The first element is not `{ 4, "hearts" }` in `list_a`, see (1)